### PR TITLE
doczにグローバルスタイルを追加した

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,3 +1,5 @@
 export default {
-  typescript: true
+  title: "otoshidama-m-front",
+  typescript: true,
+  ignore: ['README.md']
 };

--- a/src/components/buttons/Button.mdx
+++ b/src/components/buttons/Button.mdx
@@ -11,5 +11,7 @@ import Button from './Button';
 ## Basic Usage
 
 <Playground>
-  <Button>Click me</Button>
+  <div style={{margin: '20px 10px'}}>
+    <Button>Click me</Button>
+  </div>
 </Playground>

--- a/src/gatsby-theme-docz/stylesheet.css
+++ b/src/gatsby-theme-docz/stylesheet.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+div,
+span,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+a,
+img,
+ul,
+li,
+form,
+label,
+footer,
+header,
+nav {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  vertical-align: baseline;
+}
+
+html {
+  font-size: 62.5%;
+}
+
+body {
+  font-family: -apple-system, Segoe UI, Helvetica Neue,
+    Hiragino Kaku Gothic ProN, 'メイリオ', meiryo, sans-serif;
+  font-size: 1.6em;
+}
+
+ul {
+  list-style: none;
+}

--- a/src/gatsby-theme-docz/wrapper.tsx
+++ b/src/gatsby-theme-docz/wrapper.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import './stylesheet.css';
 
-const Wrapper: React.FC = ({ children }) => (
-  <>{children}</>
-);
+const Wrapper: React.FC = ({ children }) => <>{children}</>;
 
 export default Wrapper;

--- a/src/gatsby-theme-docz/wrapper.tsx
+++ b/src/gatsby-theme-docz/wrapper.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './stylesheet.css';
+
+const Wrapper: React.FC = ({ children }) => (
+  <>{children}</>
+);
+
+export default Wrapper;


### PR DESCRIPTION
- doczにコンポーネントを追加した時に、stylesheet.cssが読み込まれていないためにスタイルが崩れてしまうバグが発生していたため、設定を変更することで修正した
- README.mdがdoczのドキュメントに含まれてしまっていたため、README.mdを含めないように設定を修正した