### PR TITLE
当選結果ページのデザインを作成した

### DIFF
--- a/src/components/backgrounds/CheckBoard.mdx
+++ b/src/components/backgrounds/CheckBoard.mdx
@@ -1,0 +1,19 @@
+---
+name: CheckBoard
+menu: Backgrounds
+---
+
+import { Playground, Props } from 'docz';
+import CheckBoard from './CheckBoard';
+
+# CheckBoard
+
+チェック柄の背景を適用するためのコンポーネント
+
+## Basic Usage
+
+<Playground>
+  <CheckBoard>
+    <div style={{ width: '100%', height: '100vh' }} />
+  </CheckBoard>
+</Playground>

--- a/src/components/backgrounds/CheckBoard.tsx
+++ b/src/components/backgrounds/CheckBoard.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const CheckBoard = styled.div`
+  background:
+    linear-gradient(45deg, rgba(230, 192, 67, 0.5) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(230, 192, 67, 0.5) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(230, 192, 67, 0.5) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(230, 192, 67, 0.5) 75%);
+  background-size: 180px 180px;
+  background-position: 0 0, 0 90px, 90px -90px, -90px 0;
+`;
+
+export default CheckBoard;

--- a/src/components/cards/OtoshidamaCard.mdx
+++ b/src/components/cards/OtoshidamaCard.mdx
@@ -21,3 +21,11 @@ import OtoshidamaCard from './OtoshidamaCard';
     <OtoshidamaCard login={() => {}} fetching={false}/>
   </div>
 </Playground>
+
+## Without Login
+
+<Playground>
+  <div style={{margin: '30px', width: '100%', height: '100vh'}}>
+    <OtoshidamaCard />
+  </div>
+</Playground>

--- a/src/components/cards/OtoshidamaCard.tsx
+++ b/src/components/cards/OtoshidamaCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useCallback } from 'react';
 import styled from 'styled-components';
 import AbsoluteBorder from '../borders/AbsoluteBorder';
 import TwitterButton from '../buttons/TwitterButton';
@@ -44,20 +44,31 @@ const ButtonContainer = styled.div`
   }
 `;
 
-const OtoshidamaCard = (): ReactElement => (
-  <Card>
-    <AbsoluteBorder borderColor="#e6bf43" top={35} right={5} left={5} isVertical />
-    <AbsoluteBorder borderColor="#ed514e" right={20} top={5} bottom={5} />
-    <VerticalContent>
-      <Title>
-        お年玉-M
-        <Icon role="img" aria-label="party popper">&#x1f389;</Icon>
-      </Title>
-    </VerticalContent>
-    <ButtonContainer>
-      <TwitterButton />
-    </ButtonContainer>
-  </Card>
-);
+export interface OtoshidamaCardProps {
+  isAuth?: boolean;
+}
+
+const OtoshidamaCard = ({ isAuth }: OtoshidamaCardProps): ReactElement => {
+  const Auth = useCallback((): ReactElement | null => (
+    isAuth ? (
+      <ButtonContainer>
+        <TwitterButton />
+      </ButtonContainer>
+    ) : null), [isAuth]);
+
+  return (
+    <Card>
+      <AbsoluteBorder borderColor="#e6bf43" top={35} right={5} left={5} isVertical />
+      <AbsoluteBorder borderColor="#ed514e" right={20} top={5} bottom={5} />
+      <VerticalContent>
+        <Title>
+          お年玉-M
+          <Icon role="img" aria-label="party popper">&#x1f389;</Icon>
+        </Title>
+      </VerticalContent>
+      <Auth />
+    </Card>
+  );
+};
 
 export default OtoshidamaCard;

--- a/src/components/cards/OtoshidamaCard.tsx
+++ b/src/components/cards/OtoshidamaCard.tsx
@@ -46,18 +46,17 @@ const ButtonContainer = styled.div`
 `;
 
 export interface OtoshidamaCardProps {
-  isAuth?: boolean;
-  login: () => Promise<void>;
-  fetching: boolean;
+  login?: () => Promise<void>;
+  fetching?: boolean;
 }
 
-const OtoshidamaCard = ({ login, fetching, isAuth }: OtoshidamaCardProps): ReactElement => {
-  const Auth = useCallback((): ReactElement | null => (
-    isAuth ? (
+const OtoshidamaCard = ({ login, fetching }: OtoshidamaCardProps): ReactElement => {
+  const AuthButton = useCallback((): ReactElement | null => (
+    login ? (
       <ButtonContainer>
-        <TwitterButton onClick={login} fetching={fetching} />
+        <TwitterButton onClick={login} fetching={!!fetching} />
       </ButtonContainer>
-    ) : null), [fetching, isAuth, login]);
+    ) : null), [fetching, login]);
 
   return (
     <Card>
@@ -69,7 +68,7 @@ const OtoshidamaCard = ({ login, fetching, isAuth }: OtoshidamaCardProps): React
           <Icon role="img" aria-label="party popper">&#x1f389;</Icon>
         </Title>
       </VerticalContent>
-      <Auth />
+      <AuthButton />
     </Card>
   );
 };

--- a/src/components/cards/ResultCard.mdx
+++ b/src/components/cards/ResultCard.mdx
@@ -10,7 +10,19 @@ import ResultCard from './ResultCard';
 
 `ResultPage`で使う抽選結果を表示するための円形のカードUI
 
-## Basic Usage
+## Props
+
+<Props of={ResultCard} />
+
+## Winner
+
+<Playground>
+  <div style={{margin: '30px', width: '500px', height: '500px'}}>
+    <ResultCard isWinner />
+  </div>
+</Playground>
+
+## Loser
 
 <Playground>
   <div style={{margin: '30px', width: '500px', height: '500px'}}>

--- a/src/components/cards/ResultCard.mdx
+++ b/src/components/cards/ResultCard.mdx
@@ -1,0 +1,19 @@
+---
+name: ResultCard
+menu: Cards
+---
+
+import { Playground, Props } from 'docz';
+import ResultCard from './ResultCard';
+
+# ResultCard
+
+`ResultPage`で使う抽選結果を表示するための円形のカードUI
+
+## Basic Usage
+
+<Playground>
+  <div style={{margin: '30px', width: '500px', height: '500px'}}>
+    <ResultCard />
+  </div>
+</Playground>

--- a/src/components/cards/ResultCard.tsx
+++ b/src/components/cards/ResultCard.tsx
@@ -1,0 +1,46 @@
+import React, { useRef, useEffect, ReactElement } from 'react';
+import styled from 'styled-components';
+
+const TitleContainer = styled.div`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 1px 2px 4px #aaa;
+  width: 80%;
+  max-width: 350px;
+  border-radius: 50%;
+`;
+
+const Title = styled.h1`
+  color: #E6BF43;
+  font-size: 6rem;
+  font-weight: 900;
+  text-shadow: 2px 2px 4px #aaa;
+  margin: 0 20px;
+  @media(max-width: 320px) {
+    font-size: 5rem;
+  }
+`;
+
+const ResultCard = (): ReactElement => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.height = `${ref.current.clientWidth}px`;
+    }
+  }, [ref]);
+
+  return (
+    <TitleContainer ref={ref}>
+      <Title>当</Title>
+      <Title>選</Title>
+      <Title role="img" aria-label="party popper">&#x1f389;</Title>
+    </TitleContainer>
+  );
+};
+
+export default ResultCard;

--- a/src/components/cards/ResultCard.tsx
+++ b/src/components/cards/ResultCard.tsx
@@ -1,4 +1,6 @@
-import React, { useRef, useEffect, ReactElement } from 'react';
+import React, {
+  useRef, useEffect, ReactElement, useCallback,
+} from 'react';
 import styled from 'styled-components';
 
 const TitleContainer = styled.div`
@@ -14,19 +16,39 @@ const TitleContainer = styled.div`
   border-radius: 50%;
 `;
 
-const Title = styled.h1`
-  color: #E6BF43;
+const Title = styled.h1<{color: string}>`
+  color: ${({ color }) => color};
   font-size: 6rem;
   font-weight: 900;
   text-shadow: 2px 2px 4px #aaa;
-  margin: 0 20px;
+  writing-mode: vertical-rl;
   @media(max-width: 320px) {
     font-size: 5rem;
   }
 `;
 
-const ResultCard = (): ReactElement => {
+export interface ResultCardProps {
+  isWinner?: boolean;
+}
+
+const ResultCard = ({ isWinner }: ResultCardProps): ReactElement => {
   const ref = useRef<HTMLDivElement | null>(null);
+  const Result = useCallback(() => (isWinner ? (
+    <>
+      <Title color="#E6BF43">
+        当選
+        <span role="img" aria-label="party popper">&#x1f389;</span>
+      </Title>
+    </>
+  ) : (
+    <>
+      <Title color="#4397e6">
+        落選
+        <span role="img" aria-label="loudly crying face">&#x1f62d;</span>
+      </Title>
+    </>
+  )),
+  [isWinner]);
 
   useEffect(() => {
     if (ref.current) {
@@ -36,9 +58,7 @@ const ResultCard = (): ReactElement => {
 
   return (
     <TitleContainer ref={ref}>
-      <Title>当</Title>
-      <Title>選</Title>
-      <Title role="img" aria-label="party popper">&#x1f389;</Title>
+      <Result />
     </TitleContainer>
   );
 };

--- a/src/components/cards/ResultCard.tsx
+++ b/src/components/cards/ResultCard.tsx
@@ -22,6 +22,7 @@ const Title = styled.h1<{color: string}>`
   font-weight: 900;
   text-shadow: 2px 2px 4px #aaa;
   writing-mode: vertical-rl;
+  letter-spacing: 12px;
   @media(max-width: 320px) {
     font-size: 5rem;
   }

--- a/src/components/modals/LoadingLotteryModal.mdx
+++ b/src/components/modals/LoadingLotteryModal.mdx
@@ -1,0 +1,31 @@
+---
+name: LoadingLotteryModal
+menu: Modals
+---
+
+import { Playground, Props } from 'docz';
+import LoadingLotteryModal from './LoadingLotteryModal';
+
+# LoadingLotteryModal
+
+`ResultPage`でAPIからの抽選結果を待つときに使うモーダル
+
+## Props
+
+<Props of={LoadingLotteryModal}/>
+
+## Basic Usage
+
+<Playground>
+  <div style={{width: '100%', height: '100vh', position: 'relative'}}>
+    <LoadingLotteryModal onClick={() => {}} />
+  </div>
+</Playground>
+
+## Loading
+
+<Playground>
+  <div style={{width: '100%', height: '100vh', position: 'relative'}}>
+    <LoadingLotteryModal onClick={() => {}} fetching />
+  </div>
+</Playground>

--- a/src/components/modals/LoadingLotteryModal.tsx
+++ b/src/components/modals/LoadingLotteryModal.tsx
@@ -1,0 +1,135 @@
+import React, { ReactElement, useCallback, useState } from 'react';
+import styled, { keyframes, css } from 'styled-components';
+
+const fadeout = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
+const fadeoutAnim = css`
+  animation: ${fadeout} 500ms ease-in forwards;
+`;
+
+interface ModalProps {
+  startAnimation: boolean;
+  fetching: boolean;
+}
+
+const setModalAnimation = ({ startAnimation }: ModalProps) => (
+  startAnimation && fadeoutAnim
+);
+
+const Modal = styled.div<ModalProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.8);
+  position: absolute;
+  width: 100%;
+  height: 100vh;
+  z-index: 100;
+  padding: 0 15px;
+  cursor: ${({ fetching }) => (fetching ? 'default' : 'pointer')};
+  ${setModalAnimation}
+`;
+
+const flash = keyframes`
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const Message = styled.span`
+  font-size: 2rem;
+  font-weight: bold;
+  color: #E6BF43;
+  animation: ${flash} 1s ease-in-out infinite;
+`;
+
+const LoadingContainer = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 200px;
+  padding-bottom: 25px;
+  text-align: center;
+`;
+
+const LoadingMessage = styled.span`
+  font-size: 3rem;
+  font-weight: bold;
+  color: #fff;
+  animation: ${flash} 1.5s ease infinite;
+`;
+
+const loading = keyframes`
+  0% {
+    transform: translateX(0) rotate(0deg);
+  }
+  50% {
+    transform: translateX(180px) rotate(360deg);
+  }
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+`;
+
+const LoadingBorder = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 20px;
+  width: 20px;
+  background-color: #E6BF43;
+  animation: ${loading} 3s ease-in-out infinite;
+`;
+
+export interface LoadingLotteryModalProps {
+  fetching: boolean;
+  onClick: () => void;
+}
+
+const LoadingLotteryModal = ({
+  fetching,
+  onClick,
+}: LoadingLotteryModalProps): ReactElement | null => {
+  const [isVisible, setIsVisible] = useState(true);
+  const [startAnimation, setStartAnimation] = useState(false);
+  const Content = useCallback(() => (fetching
+    ? (
+      <LoadingContainer>
+        <LoadingMessage>抽選中...</LoadingMessage>
+        <LoadingBorder />
+      </LoadingContainer>
+    )
+    : <Message>タッチすると抽選結果が表示されます</Message>), [fetching]);
+  const handleOnClick = useCallback(() => {
+    if (fetching) return;
+    setStartAnimation(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      onClick();
+    }, 600);
+  }, [fetching, onClick]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Modal fetching={fetching} onClick={handleOnClick} startAnimation={startAnimation}>
+      <Content />
+    </Modal>
+  );
+};
+
+export default LoadingLotteryModal;

--- a/src/components/page/LotteryPage.tsx
+++ b/src/components/page/LotteryPage.tsx
@@ -1,30 +1,20 @@
 import React, { ReactElement } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import OtoshidamaCard from '../cards/OtoshidamaCard';
+import CheckBoard from '../backgrounds/CheckBoard';
 
-const BackgroundCheckBoard = css`
-  background:
-    linear-gradient(45deg, rgba(230, 192, 67, 0.5) 25%, transparent 25%),
-    linear-gradient(-45deg, rgba(230, 192, 67, 0.5) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(230, 192, 67, 0.5) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(230, 192, 67, 0.5) 75%);
-  background-size: 180px 180px;
-  background-position: 0 0, 0 90px, 90px -90px, -90px 0;
-`;
-
-const Container = styled.div`
+const Container = styled(CheckBoard)`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   width: 100%;
   height: 100vh;
-  ${BackgroundCheckBoard}
 `;
 
 const LotteryPage = (): ReactElement => (
   <Container>
-    <OtoshidamaCard />
+    <OtoshidamaCard isAuth />
   </Container>
 );
 

--- a/src/components/page/LotteryPage.tsx
+++ b/src/components/page/LotteryPage.tsx
@@ -41,7 +41,7 @@ const LotteryPage = ({ login, fetching, isError }: LotteryPageProps): ReactEleme
   return (
     <Container>
       <Alert />
-      <OtoshidamaCard login={login} fetching={fetching} isAuth />
+      <OtoshidamaCard login={login} fetching={fetching} />
     </Container>
   );
 };

--- a/src/components/page/LotteryPage.tsx
+++ b/src/components/page/LotteryPage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback } from 'react';
 import styled from 'styled-components';
-import OtoshidamaCard from '../cards/OtoshidamaCard';
 import CheckBoard from '../backgrounds/CheckBoard';
+import OtoshidamaCard from '../cards/OtoshidamaCard';
 import ErrorAlert from '../alerts/ErrorAlert';
 
 const Container = styled(CheckBoard)`

--- a/src/components/page/ResultPage.tsx
+++ b/src/components/page/ResultPage.tsx
@@ -1,34 +1,68 @@
-import React, { ReactElement } from 'react';
-import styled from 'styled-components';
+import React, { ReactElement, useCallback, useState } from 'react';
+import styled, { keyframes, css } from 'styled-components';
+import CheckBoard from '../backgrounds/CheckBoard';
+import OtoshidamaCard from '../cards/OtoshidamaCard';
+import ResultCard from '../cards/ResultCard';
+import LoadingLotteryModal from '../modals/LoadingLotteryModal';
 
-const Container = styled.div`
+const Container = styled(CheckBoard)`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   height: 100vh;
-  background-color: #fff;
+  position: relative;
 `;
 
-const TitleContainer = styled.div`
-  display: flex;
+const slide = keyframes`
+  0% {
+    transform: translateY(0) rotate(0deg) translateX(0);
+  }
+  20% {
+    transform: translateY(25%) rotate(7deg) translateX(-35px);
+  }
+  40% {
+    transform: translateY(20%) rotate(6deg) translateX(-30px);
+  }
+  100% {
+    transform: translateY(150%) rotate(35deg) translateX(-250px);
+  }
 `;
 
-const Title = styled.h1`
-  color: #E6BF43;
-  font-size: 5rem;
-  font-weight: 900;
-  text-shadow: 2px 2px 4px #aaa;
-  margin: 0 20px;
+const slideAnim = css`
+  animation: ${slide} 3s ease-out forwards;
 `;
 
-const ResultPage = (): ReactElement => (
-  <Container>
-    <TitleContainer>
-      <Title>当</Title>
-      <Title>選</Title>
-    </TitleContainer>
-  </Container>
+const setCardAnimation = ({ startAnimation }: { startAnimation: boolean }) => (
+  startAnimation && slideAnim
 );
+
+const CardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  ${setCardAnimation}
+`;
+
+const ResultPage = (): ReactElement => {
+  const [startAnimation, setStartAnimation] = useState(false);
+  const handleOnClick = useCallback(() => {
+    setStartAnimation(true);
+  }, [setStartAnimation]);
+
+  return (
+    <Container>
+      <CardWrapper startAnimation={startAnimation}>
+        <OtoshidamaCard />
+      </CardWrapper>
+      <ResultCard />
+      <LoadingLotteryModal fetching onClick={handleOnClick} />
+    </Container>
+  );
+};
 
 export default ResultPage;

--- a/src/components/page/ResultPage.tsx
+++ b/src/components/page/ResultPage.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100vh;
+  background-color: #fff;
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+`;
+
+const Title = styled.h1`
+  color: #E6BF43;
+  font-size: 5rem;
+  font-weight: 900;
+  text-shadow: 2px 2px 4px #aaa;
+  margin: 0 20px;
+`;
+
+const ResultPage = (): ReactElement => (
+  <Container>
+    <TitleContainer>
+      <Title>当</Title>
+      <Title>選</Title>
+    </TitleContainer>
+  </Container>
+);
+
+export default ResultPage;

--- a/src/components/route/Router.tsx
+++ b/src/components/route/Router.tsx
@@ -2,12 +2,14 @@ import React, { Suspense } from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import sample from './sample';
 import lotteryPage from './lotteryPage';
+import resultPage from './resultPage';
 
 const Router: React.FC = () => (
   <BrowserRouter>
     <Suspense fallback={<div>loading...</div>}>
       <Switch>
         <Route exact path="/" component={lotteryPage} />
+        <Route exact path="/result" component={resultPage} />
         <Route path="/sample" component={sample} />
       </Switch>
     </Suspense>

--- a/src/components/route/resultPage.ts
+++ b/src/components/route/resultPage.ts
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export default lazy(() => import('../page/ResultPage'));


### PR DESCRIPTION
# 作業内容
- [x] 当選結果ページのデザインの作成
- [ ] APIからのデータ取得処理

# Demo

**ローディング**

![otoshidama-m-result-loading](https://user-images.githubusercontent.com/34934510/74998667-acdcbc00-549c-11ea-9a55-120e1f5b173d.gif)

**当選**

![otoshidama-m-result-page-winner](https://user-images.githubusercontent.com/34934510/74998679-b7975100-549c-11ea-9a5d-e477249dbd11.gif)

**落選**

![otoshidama-m-result-page-loser](https://user-images.githubusercontent.com/34934510/74998698-c1b94f80-549c-11ea-91fa-472f5d15dc04.gif)

# 相談

- 次回の企画などの情報は別ページにまとめて載せる形にしようと思ったのですがどうですか?(当選結果が表示されてから数秒後に次回予告ページへのリンクが出る感じにしようと思っています)
