### PR TITLE
抽選結果ページにFetch処理を追加

### DIFF
--- a/src/components/page/ResultPage.tsx
+++ b/src/components/page/ResultPage.tsx
@@ -70,13 +70,10 @@ const ResultPage = (): ReactElement => {
   }, [setStartAnimation]);
 
   useEffect(() => {
-    const res = dummyFetch();
     const fetchWinner = async () => {
-      const { isWinner: resIsWinner } = await res;
-      setTimeout(() => {
-        setIsWinner(resIsWinner);
-        setFetching(false);
-      }, 2000);
+      const res = await dummyFetch();
+      setIsWinner(res.isWinner);
+      setFetching(false);
     };
     setFetching(true);
     fetchWinner();

--- a/src/components/page/ResultPage.tsx
+++ b/src/components/page/ResultPage.tsx
@@ -2,6 +2,7 @@ import React, {
   ReactElement, useCallback, useState, useEffect,
 } from 'react';
 import styled, { keyframes, css } from 'styled-components';
+import { useParams, useHistory } from 'react-router-dom';
 import CheckBoard from '../backgrounds/CheckBoard';
 import OtoshidamaCard from '../cards/OtoshidamaCard';
 import ResultCard from '../cards/ResultCard';
@@ -50,13 +51,14 @@ const CardWrapper = styled.div`
   ${setCardAnimation}
 `;
 
-const dummyFetch = async () => new Promise<{
+const dummyFetch = async (tweetID: string) => new Promise<{
   isWinner: boolean;
+  tweetID: string;
 }>((resolve, reject) => setTimeout(() => {
   if (Math.random() < 0.5) {
-    resolve({ isWinner: false });
+    resolve({ tweetID, isWinner: false });
   } else {
-    resolve({ isWinner: true });
+    resolve({ tweetID, isWinner: true });
   }
   // reject(new Error('Error occurred'));
 }, 1000));
@@ -65,19 +67,25 @@ const ResultPage = (): ReactElement => {
   const [fetching, setFetching] = useState(false);
   const [isWinner, setIsWinner] = useState(false);
   const [startAnimation, setStartAnimation] = useState(false);
+  const { tweetID } = useParams();
+  const history = useHistory();
   const handleOnClick = useCallback(() => {
     setStartAnimation(true);
   }, [setStartAnimation]);
 
   useEffect(() => {
     const fetchWinner = async () => {
-      const res = await dummyFetch();
+      if (!tweetID) {
+        history.push('/error/404');
+        return;
+      }
+      const res = await dummyFetch(tweetID);
       setIsWinner(res.isWinner);
       setFetching(false);
     };
     setFetching(true);
     fetchWinner();
-  }, []);
+  }, [history, tweetID]);
 
   return (
     <Container>

--- a/src/components/page/ResultPage.tsx
+++ b/src/components/page/ResultPage.tsx
@@ -1,4 +1,6 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import React, {
+  ReactElement, useCallback, useState, useEffect,
+} from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import CheckBoard from '../backgrounds/CheckBoard';
 import OtoshidamaCard from '../cards/OtoshidamaCard';
@@ -48,19 +50,45 @@ const CardWrapper = styled.div`
   ${setCardAnimation}
 `;
 
+const dummyFetch = async () => new Promise<{
+  isWinner: boolean;
+}>((resolve, reject) => setTimeout(() => {
+  if (Math.random() < 0.5) {
+    resolve({ isWinner: false });
+  } else {
+    resolve({ isWinner: true });
+  }
+  // reject(new Error('Error occurred'));
+}, 1000));
+
 const ResultPage = (): ReactElement => {
+  const [fetching, setFetching] = useState(false);
+  const [isWinner, setIsWinner] = useState(false);
   const [startAnimation, setStartAnimation] = useState(false);
   const handleOnClick = useCallback(() => {
     setStartAnimation(true);
   }, [setStartAnimation]);
+
+  useEffect(() => {
+    const res = dummyFetch();
+    const fetchWinner = async () => {
+      const { isWinner: resIsWinner } = await res;
+      setTimeout(() => {
+        setIsWinner(resIsWinner);
+        setFetching(false);
+      }, 2000);
+    };
+    setFetching(true);
+    fetchWinner();
+  }, []);
 
   return (
     <Container>
       <CardWrapper startAnimation={startAnimation}>
         <OtoshidamaCard />
       </CardWrapper>
-      <ResultCard />
-      <LoadingLotteryModal fetching onClick={handleOnClick} />
+      <ResultCard isWinner={isWinner} />
+      <LoadingLotteryModal fetching={fetching} onClick={handleOnClick} />
     </Container>
   );
 };

--- a/src/components/route/Router.tsx
+++ b/src/components/route/Router.tsx
@@ -11,7 +11,7 @@ const Router = (): ReactElement => (
     <Suspense fallback={<div>loading...</div>}>
       <Switch>
         <Route exact path="/" component={lotteryPage} />
-        <Route exact path="/result" component={resultPage} />
+        <Route exact path="/result/:tweetID" component={resultPage} />
         <Route path="/sample" component={sample} />
         <Route exact path="/setting" component={setting} />
         <Route path="/error/:statusCode" component={error} />


### PR DESCRIPTION
- [x] 抽選結果のFetch処理の追加
- [x] tweetIDを`params`から取得できるように修正

ツイートを考慮せずにUIを作っていたので、`ResultPage`とは別に企画ツイート一覧ページみたいな物を作り、選択されたツイートを元に`ResultPage`に遷移するように設計にしようと思っています！
